### PR TITLE
fix unmapped keymaps in toggleterm

### DIFF
--- a/lua/user/toggleterm.lua
+++ b/lua/user/toggleterm.lua
@@ -118,6 +118,7 @@ function M.config()
     vim.api.nvim_buf_set_keymap(0, "t", "<m-k>", [[<C-\><C-n><C-W>k]], opts)
     vim.api.nvim_buf_set_keymap(0, "t", "<m-l>", [[<C-\><C-n><C-W>l]], opts)
   end
+  vim.cmd "autocmd! TermOpen term://* lua set_terminal_keymaps()"
 end
 
 return M


### PR DESCRIPTION
In file toggleterm.lua keymaps set in `_G.set_terminal_keymaps` are never actually used