### PR TITLE
Fix - errors when launching cmd-window by q:

### DIFF
--- a/lua/user/autocmds.lua
+++ b/lua/user/autocmds.lua
@@ -41,7 +41,7 @@ vim.api.nvim_create_autocmd({ "VimResized" }, {
 })
 
 vim.api.nvim_create_autocmd({ "BufWinEnter" }, {
-  pattern = { "*" },
+  pattern = { "!vim" },
   callback = function()
     vim.cmd "checktime"
   end,


### PR DESCRIPTION
Please correct me if I am wrong, but this is how I understand it.

Due to  the presence of checktime in autocmd, when entering vim buffers like command-window (using q:), checktime is checked but as it is just a vim buffer and not a file, checktime returns nothing and that errors out.